### PR TITLE
docs: Added missing comma on Readme.md, Config Options section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Configuration options are stored in a `ssc.json` file.
         "tables": "./tables",
 
         // directory to script triggers (relative to root)
-        "triggers": "./triggers"
+        "triggers": "./triggers",
 
         // directory to script views (relative to root)
         "views": "./views"


### PR DESCRIPTION
## Description
On the readme.md there is a missing comma on the Config Options Json.

## Checklist
Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines (./CONTRIBUTING.md).
- [ ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->
```
[ ] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Build related changes.
[ ] CI related changes.
[X] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes
Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->
```
[ ] Yes
[X] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information
Since i found this situation to be very minor, i decided not to open an Issue.
