### PR TITLE
Fix the scripting for table-valued parameters

### DIFF
--- a/src/sql/script.ts
+++ b/src/sql/script.ts
@@ -132,7 +132,7 @@ export function table(
 
   // columns
   for (const col of columns.filter(x => x.object_id === item.object_id)) {
-    output += '  ' + column(col);
+    output += '  ' + column(col) + ',';
     output += EOL;
   }
 
@@ -177,10 +177,18 @@ export function tvp(
   output += EOL;
 
   // columns
-  for (const col of columns.filter(x => x.object_id === item.object_id)) {
-    output += '  ' + column(col);
-    output += EOL;
-  }
+  columns
+    .filter(x => x.object_id === item.object_id)
+    .forEach((col, idx, array) => {
+      output += '  ' + column(col);
+
+      // if it is not the last column
+      if (idx !== array.length - 1) {
+        output += ',';
+      }
+
+      output += EOL;
+    });
 
   output += ')';
   output += EOL;
@@ -240,7 +248,6 @@ function column(item: ColumnRecordSet): string {
     output += ` identity(${item.seed_value || 0}, ${item.increment_value || 1})`;
   }
 
-  output += ',';
   return output;
 }
 

--- a/src/sql/script.ts
+++ b/src/sql/script.ts
@@ -73,7 +73,7 @@ export function idempotency(item: AbstractRecordSet, type: IdempotencyOption): s
     // if not exists
     if (item.type === 'TT') {
       return [
-        'if exists (',
+        'if not exists (',
         '   select * from sys.table_types as t',
         '   join sys.schemas s on t.schema_id = s.schema_id',
         `   where t.name = '${item.name}' and s.name = '${item.schema}'`,


### PR DESCRIPTION
## Description
<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->
This pull request fixes basically two bugs related to table-valued parameters.
1. The `pull` command was not scripting the `table-valued parameters` correctly when the idempotency option is `if-not-exists`;
2. The `pull` command was scripting the comma out after the last column which is not allowed.

## Checklist
Please ensure your pull request fulfills the following requirements:

- [x] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## Type
What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->
```
[x] Bug fix.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Build related changes.
[ ] CI related changes.
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes
Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->
```
[ ] Yes
[x] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information
<!-- please include any additional information that might be helpful during review -->
fixes #22 
