### PR TITLE
fix: port type should be number instead of string

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -58,6 +58,7 @@ export default class Init {
         default: conn.port || undefined,
         message: 'Server port.',
         name: 'port',
+        type: 'number',
         when: answers => answers.path !== PathChoices.WebConfig
       },
       {


### PR DESCRIPTION
## Description
<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->
On ssc init, convert data type of port from string to number. This fixes issue #116 

## Checklist
Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [ ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->
- [X] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other (please describe below).

## Breaking Changes
Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->
[ ] Yes
[X] No

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information
<!-- please include any additional information that might be helpful during review -->
