### PR TITLE
Fix fk text cols

### DIFF
--- a/src/generators/mssql.ts
+++ b/src/generators/mssql.ts
@@ -514,13 +514,11 @@ export default class MSSQLGenerator {
       case 'char':
       case 'varbinary':
       case 'binary':
-      case 'text':
         size = item.max_length === -1 ? 'max' : item.max_length;
         output += `(${size})`;
         break;
       case 'nvarchar':
       case 'nchar':
-      case 'ntext':
         size = item.max_length === -1 ? 'max' : item.max_length / 2;
         output += `(${size})`;
         break;

--- a/src/queries/mssql.ts
+++ b/src/queries/mssql.ts
@@ -108,7 +108,8 @@ export const foreignKeysRead = `
     SCHEMA_NAME(ro.schema_id) AS [parent_schema],
     ro.name AS [parent_table],
     fk.delete_referential_action,
-    fk.update_referential_action
+    fk.update_referential_action,
+    fkc.constraint_column_id
   FROM
     sys.foreign_key_columns k
     JOIN sys.columns rc ON rc.object_id = k.referenced_object_id AND rc.column_id = k.referenced_column_id
@@ -116,6 +117,11 @@ export const foreignKeysRead = `
     JOIN sys.foreign_keys fk ON fk.object_id = k.constraint_object_id
     JOIN sys.objects ro ON ro.object_id = fk.referenced_object_id
     JOIN sys.objects po ON po.object_id = fk.parent_object_id
+    JOIN sys.foreign_key_columns fkc ON fkc.parent_object_id = fk.parent_object_id and fkc.parent_column_id = k.parent_column_id
+  ORDER BY
+    po.object_id,
+    k.constraint_object_id,
+    fkc.constraint_column_id
 `;
 
 /**


### PR DESCRIPTION
## Description

This fixes two bugs:
- Text columns do not have a dimension. `create table` statements containing a `text`or `ntext` column were not valid
- The script could not handle foreign key spanning multiple columns. 

## Checklist

Please ensure your pull request fulfills the following requirements:

- [x] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [x] Tests for any changes have been added (for bug fixes / features).
I tested the changes with our database, and it works.
For a general test, we would need a test database with tables implementing those features. Unfortunately I don't know how you set up testing.
- [x] Docs have been added / updated (for bug fixes / features).
There's nothing that has changed that needs to be documented.


## Type

What kind of change does this pull request introduce?

```
[x] Bug fix.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Build related changes.
[ ] CI related changes.
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes

Does this pull request introduce any breaking changes?

```
[ ] Yes
[x] No
```

The generated scripts differ from previous versions in these three points:
- create table statements containing text columns are now valid
- add foreign key statements spanning multiple columns are now valid
- for tables with more than one foreign key constraints, the order of the foreign keys in the generated might differ. It did not happen in my case (about 10 databases with more than 400 tables each).

## Other Information

n/a
